### PR TITLE
Render 7 and 30 day average and persist todays time after reset

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,8 +3,7 @@ import Nav from './Nav'
 import MainInfo from './MainInfo'
 import ShowerInfo from './ShowerInfo'
 import ItemCounters from './ItemCounters'
-import { useQuery, gql } from '@apollo/client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import FindUser from './FindUser';
 
 
@@ -12,19 +11,28 @@ function App() {
 
   const [todaysSeconds, setTodaysSeconds] = useState(0);
   const [todaysMinutes, setTodaysMinutes] = useState(0);
+  const [totalSeconds, setTotalSeconds] = useState(0);
+  const [totalMinutes, setTotalMinutes] = useState(0);
   const [containerCount, setContainerCount] = useState(0);
   const [bagCount, setBagCount] = useState(0);
   const [strawCount, setStrawCount] = useState(0);
   const [weeklyAverageShowerTime, setWeeklyAverageShowerTime] = useState(0);
+  const [thirtyDayAverageShowerTime, setThirtyDayAverageShowerTime] = useState(0);
+  const [username, setUsername] = useState('');
 
   return (
     <main className="App">
       <FindUser 
         weeklyAverageShowerTime={weeklyAverageShowerTime}
         setWeeklyAverageShowerTime={setWeeklyAverageShowerTime}
+        setThirtyDayAverageShowerTime={setThirtyDayAverageShowerTime}
+        thirtyDayAverageShowerTime={thirtyDayAverageShowerTime}
+        setUsername={setUsername}
       />
       <section className='nav-bar'>
-        <Nav />
+        <Nav 
+          username={username}
+        />
       </section>
       <section className='main-content'>
         <MainInfo />
@@ -33,6 +41,13 @@ function App() {
           setTodaysSeconds={setTodaysSeconds}
           todaysMinutes={todaysMinutes}
           setTodaysMinutes={setTodaysMinutes}
+          weeklyAverageShowerTime={weeklyAverageShowerTime}
+          setTotalSeconds={setTotalSeconds}
+          totalSeconds={totalSeconds}
+          setTotalMinutes={setTotalMinutes}
+          totalMinutes={totalMinutes}
+          setThirtyDayAverageShowerTime={setThirtyDayAverageShowerTime}
+          thirtyDayAverageShowerTime={thirtyDayAverageShowerTime}
         />
       </section>
       <section className='item-counters'>

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -5,7 +5,7 @@ import MenuItem from '@mui/material/MenuItem';
 import '../styles/DropdownMenu.css'
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 
-export default function DropdownMenu() {
+export default function DropdownMenu({ username }) {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -39,6 +39,7 @@ export default function DropdownMenu() {
           'aria-labelledby': 'basic-button',
         }}
       >
+        <MenuItem className='menu-item' id='log-in-msg'>{username} is logged in</MenuItem>
         <MenuItem className='menu-item' onClick={handleClose}>5 Min Shower</MenuItem>
         <MenuItem className='menu-item' onClick={handleClose}>Recycling</MenuItem>
         <MenuItem className='menu-item' onClick={handleClose}>Composting</MenuItem>

--- a/src/components/FindUser.js
+++ b/src/components/FindUser.js
@@ -2,13 +2,15 @@ import { useQuery, gql } from '@apollo/client';
 import { useEffect } from 'react';
 import { GET_USER } from './Queries'
 
-function FindUser({ weeklyAverageShowerTime, setWeeklyAverageShowerTime}) {
+function FindUser({ setWeeklyAverageShowerTime, setThirtyDayAverageShowerTime, setUsername}) {
     const { loading, error, data } = useQuery(GET_USER);
 
     useEffect(() => {
         if (data) {
             console.log(data.getUser.weeklyAverageShowerTime)
             setWeeklyAverageShowerTime(data.getUser.weeklyAverageShowerTime)
+            setThirtyDayAverageShowerTime(data.getUser.thirtydayAverageShowerTime)
+            setUsername(data.getUser.username)
         }
     }, [data])
 }

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -2,14 +2,17 @@ import '../styles/Nav.css'
 import DropdownMenu from './DropdownMenu'
 
 
-const Nav = () => {
+const Nav = ({ username }) => {
   return (
     <nav className='nav'>
       <section className='nav-title-logo'>
         <p className='nav-title'>PlanIt</p>
         <img src='../assets/app-logo.png' alt='logo of earth with leaves sprouting and wrapping around' className='nav-logo'/>
       </section>
-      <DropdownMenu />
+      <DropdownMenu 
+        id='nav-btn'
+        username={username}
+      />
     </nav>
   )
 }

--- a/src/components/Queries.js
+++ b/src/components/Queries.js
@@ -2,12 +2,13 @@ import { gql } from '@apollo/client'
 
 export const GET_USER = gql`
     query getUser {
-      getUser(id: "6") {
+      getUser(id: "8") {
         id
         username
         flowrate
         weeklyAverageShowerTime
         weeklyAverageWaterUsage
+        thirtydayAverageShowerTime
       }
     }
   `;

--- a/src/components/ShowerInfo.js
+++ b/src/components/ShowerInfo.js
@@ -2,9 +2,19 @@ import '../styles/ShowerInfo.css'
 import { useStopwatch } from 'react-timer-hook';
 import { useEffect } from 'react';
 
-const ShowerInfo = ({ todaysSeconds, todaysMinutes, setTodaysSeconds, setTodaysMinutes }) => {
+const ShowerInfo = ({ 
+  todaysSeconds, 
+  todaysMinutes, 
+  setTodaysSeconds, 
+  setTodaysMinutes, 
+  setTotalSeconds, 
+  totalSeconds, 
+  setTotalMinutes, 
+  totalMinutes, 
+  weeklyAverageShowerTime, 
+  thirtyDayAverageShowerTime }) => {
 
-  const {
+  let {
     seconds,
     minutes,
     isRunning,
@@ -14,34 +24,47 @@ const ShowerInfo = ({ todaysSeconds, todaysMinutes, setTodaysSeconds, setTodaysM
   } = useStopwatch({ autoStart: false });
 
   useEffect(() => {
-    setTodaysSeconds(seconds)
+    if (todaysSeconds < 10) {
+      setTodaysSeconds('0' + seconds)
+    } else {
+      setTodaysSeconds(seconds)
+    }
   }, [seconds])
 
   useEffect(() => {
     setTodaysMinutes(minutes)
   }, [minutes])
 
+  const setTotalShowerTime = (sec, min) => {
+    setTotalSeconds(sec)
+    setTotalMinutes(min)
+  }
+
+  
+
   return (
     <section className='info-container'>
-      <div style={{textAlign: 'center'}}>
-        <p>Your Shower Timer</p>
-        <div style={{fontSize: '100px'}}>
+      <div className='timer-container'style={{textAlign: 'center'}}>
+        <p className='timer-title'>Your Shower Timer</p>
+        <div className='timer-nums'style={{fontSize: '100px'}}>
           <span>{minutes}</span>:<span>{seconds}</span>
         </div>
-        <button onClick={start}>Start</button>
-        <button onClick={pause}>Pause</button>
-        <button onClick={reset}>Reset</button>
+        <div className='timer-btn-container'>
+          <button className='timer-btn' onClick={start}>Start</button>
+          <button className='timer-btn' onClick={() => {pause(); setTotalShowerTime(todaysSeconds, todaysMinutes)}}>Pause</button>
+          <button className='timer-btn' onClick={() => {reset(); pause()}}>Reset</button>
+        </div>
       </div>
       <div className='shower-data'>
         <div className='shower-data-text-box'>
-          <h3 className='shower-data-text'>Average</h3>
           <h3 className='shower-data-text'>Today</h3>
-          <h3 className='shower-data-text'>The Week's Total</h3>
+          <h3 className='shower-data-text'>7 Day Average</h3>
+          <h3 className='shower-data-text'>30 Day Average</h3>
         </div>
         <div className='shower-data-num-box'>
-          <h3 className='shower-data-num'>6:19</h3>
-          <h3 className='shower-data-num'>{todaysMinutes}:{todaysSeconds}</h3>
-          <h3 className='shower-data-num'>7:12</h3>
+          <h3 className='shower-data-num'>{totalMinutes}:{totalSeconds}</h3>
+          <h3 className='shower-data-num'>{Math.floor(weeklyAverageShowerTime/60)}:{weeklyAverageShowerTime % 60}</h3>
+          <h3 className='shower-data-num'>{Math.floor(thirtyDayAverageShowerTime/60)}:{thirtyDayAverageShowerTime % 60}</h3>
         </div>
       </div>
     </section>

--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,13 @@ client
   .query({
     query: gql`
       query getUser {
-        getUser(id: "6") {
+        getUser(id: "8") {
           id
           username
           flowrate
           weeklyAverageShowerTime
           weeklyAverageWaterUsage
+          thirtydayAverageShowerTime
         }
       }
     `,

--- a/src/styles/DropdownMenu.css
+++ b/src/styles/DropdownMenu.css
@@ -9,3 +9,8 @@
 #burger-icon {
   transform: scale(150%);
 }
+
+#log-in-msg {
+  background-color: #DCF6C7;
+  cursor: auto;
+}

--- a/src/styles/ShowerInfo.css
+++ b/src/styles/ShowerInfo.css
@@ -19,15 +19,54 @@
   width: 40%;
   align-items: center;
   justify-content: space-around;
-  margin: 3vh 3vw;
+  margin: 0vh 3vw;
   font-size: 26px;
 }
 
 .shower-data-text {
-  margin: 2vh 0vw;
+  margin: 4vh 0vw;
+  letter-spacing: 2px;
 }
 
 .shower-data-num {
-  margin: 2vh 0vw;
-  letter-spacing: 2px;
+  margin: 4vh 0vw;
+  letter-spacing: 3px;
+}
+
+.timer-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 40%;
+  margin: 2vh 2vw;
+}
+
+.timer-title {
+  font-size: 26px;
+}
+
+.timer-btn-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  height: 35%;
+}
+
+.timer-btn {
+  width: 7vw;
+  height: 2.5vh;
+  border: none;
+  border-radius: 4px;
+  background-color: #DCF6C7;
+}
+
+.timer-btn:hover {
+  transform: translateY(-2px);
+  transition: ease-in 0.15s;
+}
+
+.timer-btn:active {
+  transform: translateY(0px);
+  transition: ease-in 0.15s;
 }


### PR DESCRIPTION
# Description

Add 7 day and 30 day averages to the appropriate fields.
Allow the timer data to persist in Today's Time section after timer reset
Style updates to timer and dropdown button

Still needs some final tweaks to format the times properly, I wasn't able to figure it out

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor feature (non-breaking change that modifies existing work)
- [x] Cosmetic changes (changes to layout or visuals in CSS file)


## How Has This Been Tested?

- [x] console.log()
- [ ] dev tools
- [x] functionality check through web browser
- [ ] tested by viewing the markdown file preview
- [ ] tested with testing framework


## Checklist:

- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deleted all comments/console.log() after functionality and understanding is final
- [x] I have added any issues closed by this PR in the Issues section.
- [x] I have added others as reviewers
