### PR TITLE
Bug fix/timer functionality

### DIFF
--- a/src/components/ShowerInfo.js
+++ b/src/components/ShowerInfo.js
@@ -46,6 +46,12 @@ const ShowerInfo = ({
     }
   }
 
+  const resetShower = () => {
+    setTotalSeconds(0)
+    setTotalMinutes(0)
+    reset();
+  }
+
 
   return (
     <section className='info-container'>
@@ -57,7 +63,7 @@ const ShowerInfo = ({
         <div className='timer-btn-container'>
           <button className='timer-btn' onClick={startShower}>Start</button>
           <button className='timer-btn' onClick={() => {pause(); setTotalShowerTime(todaysSeconds, todaysMinutes)}}>Pause</button>
-          <button className='timer-btn' onClick={() => {reset(); pause()}}>Reset</button>
+          <button className='timer-btn' onClick={() => {pause(); resetShower()}}>Reset</button>
         </div>
       </div>
       <div className='shower-data'>
@@ -67,7 +73,7 @@ const ShowerInfo = ({
           <h3 className='shower-data-text'>30 Day Average</h3>
         </div>
         <div className='shower-data-num-box'>
-          <h3 className='shower-data-num'>{totalMinutes}:{totalSeconds}</h3>
+          <h3 className='shower-data-num'>{todaysMinutes}:{todaysSeconds}</h3>
           <h3 className='shower-data-num'>{Math.floor(weeklyAverageShowerTime/60)}:{weeklyAverageShowerTime % 60}</h3>
           <h3 className='shower-data-num'>{Math.floor(thirtyDayAverageShowerTime/60)}:{thirtyDayAverageShowerTime % 60}</h3>
         </div>
@@ -79,5 +85,10 @@ const ShowerInfo = ({
 // If a user clicks start while the timer is already running, don't reset it.
   // Fixed - used the built in isRunning
 // As the timer changes, reflect the new state in the UI
+  // Fixed - had to JavaScript interpolate a different piece of state to reflect this
+// When the timer is reset, then the user clicks 'start' the time resets to the last time. Fix this 
+  // Fixed - had to add a helper function that resets the total minutes and seconds in state back to 0,
+  // Put the reset function inside of this helper function
+  // Had to change the order in which the two functions were invoked when the reset button is clicked
 
 export default ShowerInfo;

--- a/src/components/ShowerInfo.js
+++ b/src/components/ShowerInfo.js
@@ -2,16 +2,16 @@ import '../styles/ShowerInfo.css'
 import { useStopwatch } from 'react-timer-hook';
 import { useEffect } from 'react';
 
-const ShowerInfo = ({ 
-  todaysSeconds, 
-  todaysMinutes, 
-  setTodaysSeconds, 
-  setTodaysMinutes, 
-  setTotalSeconds, 
-  totalSeconds, 
-  setTotalMinutes, 
-  totalMinutes, 
-  weeklyAverageShowerTime, 
+const ShowerInfo = ({
+  todaysSeconds,
+  todaysMinutes,
+  setTodaysSeconds,
+  setTodaysMinutes,
+  setTotalSeconds,
+  totalSeconds,
+  setTotalMinutes,
+  totalMinutes,
+  weeklyAverageShowerTime,
   thirtyDayAverageShowerTime }) => {
 
   let {
@@ -40,7 +40,12 @@ const ShowerInfo = ({
     setTotalMinutes(min)
   }
 
-  
+  const startShower = () => {
+    if (!isRunning) {
+      start()
+    }
+  }
+
 
   return (
     <section className='info-container'>
@@ -50,7 +55,7 @@ const ShowerInfo = ({
           <span>{minutes}</span>:<span>{seconds}</span>
         </div>
         <div className='timer-btn-container'>
-          <button className='timer-btn' onClick={start}>Start</button>
+          <button className='timer-btn' onClick={startShower}>Start</button>
           <button className='timer-btn' onClick={() => {pause(); setTotalShowerTime(todaysSeconds, todaysMinutes)}}>Pause</button>
           <button className='timer-btn' onClick={() => {reset(); pause()}}>Reset</button>
         </div>
@@ -71,8 +76,8 @@ const ShowerInfo = ({
   )
 }
 
-// Add button to record time, or auto post at midnight?
-
-// Fetch user's average time and weekly total. Display them.
+// If a user clicks start while the timer is already running, don't reset it.
+  // Fixed - used the built in isRunning
+// As the timer changes, reflect the new state in the UI
 
 export default ShowerInfo;


### PR DESCRIPTION
# Description

This PR fixes the several small bugs in timer functionality. 
1. If the timer is running and a user clicks start again, the timer should no longer reset. (Fixed - nothing at all happens now)
2. As the timer changes, the UI is no longer constantly reflecting this. (Fixed - had to reference a different piece of state)
3. When the timer is 'reset', 'today's time' should reflect this. (Fixed - added a helper function to reset state and reset the timer, switched the invocation order of the two functions invoked on 'reset' click)

I have added more detailed comments in the ShowerInfo.js file explaining fixes. 

## Issues

Closes #9
Closes #17 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Cosmetic changes (changes to layout or visuals in CSS file)


## How Has This Been Tested?

- [x] console.log()
- [x] dev tools
- [x] functionality check through web browser
- [ ] tested by viewing the markdown file preview
- [ ] tested with testing framework (CI)


## Checklist:

- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deleted all comments/console.log() after functionality and understanding is final
- [x] I have added any issues closed by this PR in the Issues section.
- [x] I have added others as reviewers
